### PR TITLE
Fix deprecation warnings in Flask app

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import json
 from flask import Flask, request, jsonify, session, redirect
 from db.models import db, Product, PriceHistory
 from apscheduler.schedulers.background import BackgroundScheduler
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Simple token storage
 def save_token(token):
@@ -70,7 +70,7 @@ def create_app():
         new_reg = prod_data["price"]["regular"]
         new_pr = prod_data["price"]["promo"]
 
-        existing = Product.query.get(pid)
+        existing = db.session.get(Product, pid)
 
         if existing:
             old_pr = existing.promo_price or 0
@@ -85,7 +85,7 @@ def create_app():
                     product_id=pid, promo_price=new_pr, regular_price=new_reg
                 )
                 db.session.add(history)
-                print(f"✅ Polled prices at {datetime.utcnow().isoformat()}")
+                print(f"✅ Polled prices at {datetime.now(timezone.utc).isoformat()}")
                 db.session.commit()
                 print(f"🔔 Price drop for {pid}: {old_pr} → {new_pr}")
                 return {"alert": True, "old_price": old_pr, "new_price": new_pr}
@@ -95,7 +95,7 @@ def create_app():
                 product_id=pid, promo_price=new_pr, regular_price=new_reg
             )
             db.session.add(history)
-            print(f"✅ Polled prices at {datetime.utcnow().isoformat()}")
+            print(f"✅ Polled prices at {datetime.now(timezone.utc).isoformat()}")
             db.session.commit()
             return {"alert": False}
 
@@ -125,7 +125,7 @@ def create_app():
             product_id=pid, promo_price=new_pr, regular_price=new_reg
         )
         db.session.add(history)
-        print(f"✅ Polled prices at {datetime.utcnow().isoformat()}")
+        print(f"✅ Polled prices at {datetime.now(timezone.utc).isoformat()}")
         db.session.commit()
         return {"alert": True, "new_price": new_pr}
 

--- a/db/models.py
+++ b/db/models.py
@@ -1,5 +1,5 @@
 from flask_sqlalchemy import SQLAlchemy
-from datetime import datetime
+from datetime import datetime, timezone
 
 db = SQLAlchemy()
 
@@ -28,7 +28,9 @@ class PriceHistory(db.Model):
     __tablename__ = "price_history"
     id = db.Column(db.Integer, primary_key=True)
     product_id = db.Column(db.String, db.ForeignKey("products.id"), nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    timestamp = db.Column(
+        db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     promo_price = db.Column(db.Float, nullable=False)
     regular_price = db.Column(db.Float, nullable=False)
 


### PR DESCRIPTION
## Summary
- avoid SQLAlchemy `Query.get` deprecation by using `db.session.get`
- replace deprecated `datetime.utcnow` with timezone-aware version
- make `PriceHistory.timestamp` store timezone-aware datetimes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852e5ad1b588332b30a7fae37d02a91